### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Include `dependency_manager.rb` in your Vagrantfile and call the function `check
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-require File.dirname(__FILE__)+"./dependency_manager"
+require File.dirname(__FILE__)+"/dependency_manager"
 
 check_plugins ["vagrant-exec", "vagrant-hostsupdater", "vagrant-cachier", "vagrant-triggers"]
 


### PR DESCRIPTION
There is no need for DOT in the path file. It causes import error.
require File.dirname(__FILE__)+"./dependency_manager"